### PR TITLE
Add metrics to new dashboard panels

### DIFF
--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -18,7 +18,7 @@ import {
 } from '@/components/sidebar'; // Sidebar components
 import { SidebarLayout } from '@/components/sidebar-layout'; // SidebarLayout component
 import { Avatar } from '@/components/avatar'; // Assuming Catalyst Avatar
-import { MagnifyingGlassIcon, Cog8ToothIcon, ArrowRightStartOnRectangleIcon } from '@heroicons/react/24/outline'; // Example icons
+import { HomeIcon, ClipboardDocumentListIcon, BanknotesIcon, CpuChipIcon, MagnifyingGlassIcon, Cog8ToothIcon, ArrowRightStartOnRectangleIcon } from '@heroicons/react/24/outline';
 import { Strong } from '@/components/text'; // Assuming Catalyst Text components
 
 export default function DashboardLayout({
@@ -28,10 +28,10 @@ export default function DashboardLayout({
 }) {
   // Placeholder navigation items
   const navigation = [
-    { name: 'Dashboard Home', href: '/dashboard', current: true }, // Example
-    { name: 'Prior Authorization', href: '#prior-auth', current: false },
-    { name: 'Claims Management', href: '#claims-mgmt', current: false },
-    { name: 'Agent Monitoring', href: '#agent-monitor', current: false },
+    { name: 'Dashboard Home', href: '/dashboard', icon: HomeIcon, current: true },
+    { name: 'Prior Authorization', href: '#prior-auth', icon: ClipboardDocumentListIcon, current: false },
+    { name: 'Claims Management', href: '#claims-mgmt', icon: BanknotesIcon, current: false },
+    { name: 'Agent Monitoring', href: '#agent-monitor', icon: CpuChipIcon, current: false },
   ];
 
   return (
@@ -51,7 +51,7 @@ export default function DashboardLayout({
         </Navbar>
       }
       sidebar={
-        <Sidebar>
+        <Sidebar className="bg-gradient-to-b from-zinc-900 via-zinc-800 to-black text-zinc-200 shadow-xl">
           <SidebarHeader>
             {/* Logo can go here if desired, or a title */}
             <Strong className="text-xl text-white">Ron AI</Strong>
@@ -60,17 +60,17 @@ export default function DashboardLayout({
             <SidebarSection>
               {navigation.map((item) => (
                 <SidebarItem key={item.name} href={item.href} current={item.current}>
-                  {/* Add icons here if available/desired */}
+                  {item.icon && <item.icon className="w-5 h-5" />}
                   <SidebarLabel>{item.name}</SidebarLabel>
                 </SidebarItem>
               ))}
             </SidebarSection>
-            <SidebarSection className="mt-auto">
+            <SidebarSection className="mt-auto border-t border-zinc-800 pt-4">
               <SidebarItem href="#">
                 <Cog8ToothIcon />
                 <SidebarLabel>Settings</SidebarLabel>
               </SidebarItem>
-              <SidebarItem href="/logout"> {/* Or handle logout via function */}
+              <SidebarItem href="/logout">
                 <ArrowRightStartOnRectangleIcon />
                 <SidebarLabel>Logout</SidebarLabel>
               </SidebarItem>

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,11 +1,14 @@
 'use client';
 
-import React from 'react';
+import React, { useState } from 'react';
 import { motion } from 'framer-motion';
 import { ActiveTasksPanel } from '@/components/dashboard/active-tasks/active-tasks-panel';
 import { PriorAuthMetrics } from '@/components/dashboard/prior-auth/prior-auth-metrics';
 import { ClaimsMetricsPanel } from '@/components/dashboard/claims-management/claims-metrics-panel';
 import { AgentStatusPanel } from '@/components/dashboard/agent-monitoring/agent-status-panel';
+import { AppealsMetricsPanel } from '@/components/dashboard/appeals/appeals-metrics-panel';
+import { CareJourneysMetricsPanel } from '@/components/dashboard/care-journeys/care-journeys-metrics-panel';
+import { AppointmentsMetricsPanel } from '@/components/dashboard/appointments/appointments-metrics-panel';
 
 export default function DashboardPage() {
   // Page fade-in animation
@@ -23,6 +26,17 @@ export default function DashboardPage() {
     hidden: { opacity: 0, y: 20 },
     visible: { opacity: 1, y: 0 },
   };
+
+  const tabs = [
+    { id: 'prior', label: 'Prior Authorizations' },
+    { id: 'claims', label: 'Claims' },
+    { id: 'appeals', label: 'Appeals' },
+    { id: 'care', label: 'Care Journeys' },
+    { id: 'agents', label: 'Agent Monitoring' },
+    { id: 'appointments', label: 'Appointments' },
+  ];
+
+  const [activeTab, setActiveTab] = useState<string>('prior');
 
   return (
     <motion.div
@@ -43,22 +57,31 @@ export default function DashboardPage() {
         <ActiveTasksPanel />
       </motion.div>
 
-      {/* Prior Auth Metrics */}
+      {/* Dashboard Tabs */}
       <motion.div variants={itemVariants} className="mb-8">
-        <h2 className="text-xl font-semibold text-white mb-4">Prior Authorization</h2>
-        <PriorAuthMetrics />
+        <div className="flex flex-wrap gap-2">
+          {tabs.map((t) => (
+            <motion.button
+              key={t.id}
+              onClick={() => setActiveTab(t.id)}
+              className={`px-3 py-1.5 rounded-md text-sm font-medium ${activeTab === t.id ? 'text-white' : 'text-zinc-400'}`}
+              animate={activeTab === t.id ? { rotate: [0, 360, 0], backgroundColor: '#4f46e5', boxShadow: '0 0 8px #6366f1' } : { backgroundColor: 'transparent', boxShadow: 'none' }}
+              transition={{ duration: 0.6 }}
+            >
+              {t.label}
+            </motion.button>
+          ))}
+        </div>
       </motion.div>
 
-      {/* Claims Management */}
-      <motion.div variants={itemVariants} className="mb-8">
-        <h2 className="text-xl font-semibold text-white mb-4">Claims Management</h2>
-        <ClaimsMetricsPanel />
-      </motion.div>
-      
-      {/* Agent Monitoring */}
-      <motion.div variants={itemVariants}>
-        <h2 className="text-xl font-semibold text-white mb-4">Agent Monitoring</h2>
-        <AgentStatusPanel />
+      {/* Tab Panels */}
+      <motion.div variants={itemVariants} className="space-y-8">
+        {activeTab === 'prior' && <PriorAuthMetrics />}
+        {activeTab === 'claims' && <ClaimsMetricsPanel />}
+        {activeTab === 'appeals' && <AppealsMetricsPanel />}
+        {activeTab === 'care' && <CareJourneysMetricsPanel />}
+        {activeTab === 'agents' && <AgentStatusPanel />}
+        {activeTab === 'appointments' && <AppointmentsMetricsPanel />}
       </motion.div>
     </motion.div>
   );

--- a/src/components/dashboard/appeals/appeals-metrics-panel.tsx
+++ b/src/components/dashboard/appeals/appeals-metrics-panel.tsx
@@ -1,0 +1,141 @@
+'use client';
+
+import React from 'react';
+import { AnimatedMetric } from '@/components/ui/animated-metric';
+import { GlassCard } from '@/components/ui/glass-card';
+import { chartColors } from '@/components/ui/chart-config';
+import { Chart as ChartJS, CategoryScale, LinearScale, LineElement, PointElement, Title, Tooltip, Legend, Filler } from 'chart.js';
+import { Line } from 'react-chartjs-2';
+
+ChartJS.register(CategoryScale, LinearScale, LineElement, PointElement, Title, Tooltip, Legend, Filler);
+
+interface AppealsMetricsPanelProps {
+  className?: string;
+}
+
+export function AppealsMetricsPanel({ className }: AppealsMetricsPanelProps) {
+  const resolutionData = {
+    labels: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun'],
+    datasets: [
+      {
+        label: 'Resolution Time',
+        data: [14, 13, 11, 10, 9, 8],
+        borderColor: chartColors.blue,
+        backgroundColor: chartColors.blueAlpha,
+        tension: 0.4,
+        fill: true,
+        pointRadius: 3,
+      },
+    ],
+  };
+
+  const resolutionOptions = {
+    responsive: true,
+    maintainAspectRatio: false,
+    scales: {
+      y: {
+        beginAtZero: true,
+        grid: { color: 'rgba(255, 255, 255, 0.05)' },
+        ticks: { color: '#ededed', font: { size: 11 } },
+        title: { display: true, text: 'Days', color: '#ededed', font: { size: 12 } },
+      },
+      x: {
+        grid: { display: false },
+        ticks: { color: '#ededed', font: { size: 11 } },
+      },
+    },
+    plugins: {
+      legend: { display: false },
+      tooltip: {
+        backgroundColor: 'rgba(26, 26, 26, 0.9)',
+        titleColor: '#ffffff',
+        bodyColor: '#ededed',
+        borderColor: 'rgba(255, 255, 255, 0.1)',
+        borderWidth: 1,
+        padding: 10,
+        boxPadding: 6,
+      },
+    },
+  };
+
+  const miniLineOptions = {
+    responsive: true,
+    maintainAspectRatio: false,
+    scales: {
+      y: { display: false },
+      x: { display: false },
+    },
+    plugins: { legend: { display: false }, tooltip: { enabled: false } },
+  };
+
+  const successTrendData = {
+    labels: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun'],
+    datasets: [
+      {
+        label: 'Success %',
+        data: [70, 72, 74, 75, 76, 78],
+        borderColor: chartColors.green,
+        backgroundColor: chartColors.greenAlpha,
+        tension: 0.4,
+        fill: true,
+        pointRadius: 0,
+      },
+    ],
+  };
+
+  const filedTrendData = {
+    labels: ['Week 1', 'Week 2', 'Week 3', 'Week 4'],
+    datasets: [
+      {
+        label: 'Filed',
+        data: [30, 28, 32, 22],
+        borderColor: chartColors.blue,
+        backgroundColor: chartColors.blueAlpha,
+        tension: 0.4,
+        fill: true,
+        pointRadius: 0,
+      },
+    ],
+  };
+
+  return (
+    <div className={`grid grid-cols-1 lg:grid-cols-4 gap-4 ${className}`}>
+      <GlassCard glow="blue">
+        <div className="p-5 text-center">
+          <h3 className="text-zinc-400 text-sm font-medium mb-2">Open Appeals</h3>
+          <AnimatedMetric value={37} className="text-4xl font-bold text-white" />
+        </div>
+      </GlassCard>
+
+      <GlassCard glow="blue">
+        <div className="p-5 text-center">
+          <h3 className="text-zinc-400 text-sm font-medium mb-2">Success Rate</h3>
+          <AnimatedMetric value={78} suffix="%" className="text-3xl font-bold text-white" />
+          <div className="w-full h-12 mt-4">
+            <Line options={miniLineOptions} data={successTrendData} />
+          </div>
+        </div>
+      </GlassCard>
+
+      <GlassCard glow="blue">
+        <div className="p-5 text-center">
+          <h3 className="text-zinc-400 text-sm font-medium mb-2">Appeals Filed (MTD)</h3>
+          <AnimatedMetric value={112} className="text-3xl font-bold text-white" />
+          <div className="w-full h-12 mt-4">
+            <Line options={miniLineOptions} data={filedTrendData} />
+          </div>
+        </div>
+      </GlassCard>
+
+      <GlassCard glow="blue" className="lg:col-span-4">
+        <div className="p-5">
+          <h3 className="text-zinc-400 text-sm font-medium mb-2">Avg. Resolution Time</h3>
+          <div className="h-64">
+            <Line options={resolutionOptions} data={resolutionData} />
+          </div>
+        </div>
+      </GlassCard>
+    </div>
+  );
+}
+

--- a/src/components/dashboard/appointments/appointments-metrics-panel.tsx
+++ b/src/components/dashboard/appointments/appointments-metrics-panel.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import React from 'react';
+import { AnimatedMetric } from '@/components/ui/animated-metric';
+import { GlassCard } from '@/components/ui/glass-card';
+import { chartColors } from '@/components/ui/chart-config';
+import { Chart as ChartJS, CategoryScale, LinearScale, LineElement, PointElement, Title, Tooltip, Legend, Filler } from 'chart.js';
+import { Line } from 'react-chartjs-2';
+
+ChartJS.register(CategoryScale, LinearScale, LineElement, PointElement, Title, Tooltip, Legend, Filler);
+
+interface AppointmentsMetricsPanelProps {
+  className?: string;
+}
+
+export function AppointmentsMetricsPanel({ className }: AppointmentsMetricsPanelProps) {
+  const waitTimeData = {
+    labels: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri'],
+    datasets: [
+      {
+        label: 'Avg Wait Time',
+        data: [25, 20, 22, 18, 15],
+        borderColor: chartColors.blue,
+        backgroundColor: chartColors.blueAlpha,
+        tension: 0.4,
+        fill: true,
+        pointRadius: 3,
+      },
+    ],
+  };
+
+  const lineOptions = {
+    responsive: true,
+    maintainAspectRatio: false,
+    scales: {
+      y: {
+        beginAtZero: true,
+        grid: { color: 'rgba(255, 255, 255, 0.05)' },
+        ticks: { color: '#ededed', font: { size: 11 } },
+      },
+      x: {
+        grid: { display: false },
+        ticks: { color: '#ededed', font: { size: 11 } },
+      },
+    },
+    plugins: {
+      legend: { display: false },
+      tooltip: {
+        backgroundColor: 'rgba(26, 26, 26, 0.9)',
+        titleColor: '#ffffff',
+        bodyColor: '#ededed',
+        borderColor: 'rgba(255, 255, 255, 0.1)',
+        borderWidth: 1,
+        padding: 10,
+        boxPadding: 6,
+      },
+    },
+  };
+
+  const miniLineOptions = {
+    responsive: true,
+    maintainAspectRatio: false,
+    scales: {
+      y: { display: false },
+      x: { display: false },
+    },
+    plugins: { legend: { display: false }, tooltip: { enabled: false } },
+  };
+
+  const noShowData = {
+    labels: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri'],
+    datasets: [
+      {
+        label: 'No Show %',
+        data: [8, 7, 6, 9, 5],
+        borderColor: chartColors.red,
+        backgroundColor: chartColors.redAlpha,
+        tension: 0.4,
+        fill: true,
+        pointRadius: 0,
+      },
+    ],
+  };
+
+  return (
+    <div className={`grid grid-cols-1 lg:grid-cols-4 gap-4 ${className}`}>
+      <GlassCard glow="blue">
+        <div className="p-5 text-center">
+          <h3 className="text-zinc-400 text-sm font-medium mb-2">Upcoming Appointments</h3>
+          <AnimatedMetric value={58} className="text-4xl font-bold text-white" />
+        </div>
+      </GlassCard>
+
+      <GlassCard glow="blue">
+        <div className="p-5 text-center">
+          <h3 className="text-zinc-400 text-sm font-medium mb-2">Completed Today</h3>
+          <AnimatedMetric value={46} className="text-3xl font-bold text-white" />
+        </div>
+      </GlassCard>
+
+      <GlassCard glow="blue">
+        <div className="p-5 text-center">
+          <h3 className="text-zinc-400 text-sm font-medium mb-2">No-Show Rate</h3>
+          <AnimatedMetric value={6} suffix="%" className="text-3xl font-bold text-white" />
+          <div className="w-full h-12 mt-4">
+            <Line options={miniLineOptions} data={noShowData} />
+          </div>
+        </div>
+      </GlassCard>
+
+      <GlassCard glow="blue" className="lg:col-span-4">
+        <div className="p-5">
+          <h3 className="text-zinc-400 text-sm font-medium mb-2">Avg Wait Time</h3>
+          <div className="h-64">
+            <Line options={lineOptions} data={waitTimeData} />
+          </div>
+        </div>
+      </GlassCard>
+    </div>
+  );
+}
+

--- a/src/components/dashboard/care-journeys/care-journeys-metrics-panel.tsx
+++ b/src/components/dashboard/care-journeys/care-journeys-metrics-panel.tsx
@@ -1,0 +1,137 @@
+'use client';
+
+import React from 'react';
+import { AnimatedMetric } from '@/components/ui/animated-metric';
+import { GlassCard } from '@/components/ui/glass-card';
+import { chartColors } from '@/components/ui/chart-config';
+import { Chart as ChartJS, CategoryScale, LinearScale, BarElement, LineElement, PointElement, Title, Tooltip, Legend, Filler } from 'chart.js';
+import { Bar, Line } from 'react-chartjs-2';
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, LineElement, PointElement, Title, Tooltip, Legend, Filler);
+
+interface CareJourneysMetricsPanelProps {
+  className?: string;
+}
+
+export function CareJourneysMetricsPanel({ className }: CareJourneysMetricsPanelProps) {
+  const completionData = {
+    labels: ['Diabetes', 'Cardio', 'Maternity', 'Oncology'],
+    datasets: [
+      {
+        label: 'Completion %',
+        data: [82, 76, 91, 68],
+        backgroundColor: chartColors.blue,
+        borderRadius: 4,
+      },
+    ],
+  };
+
+  const barOptions = {
+    responsive: true,
+    maintainAspectRatio: false,
+    scales: {
+      x: {
+        grid: { color: 'rgba(255, 255, 255, 0.05)' },
+        ticks: { color: '#ededed', font: { size: 11 } },
+      },
+      y: {
+        beginAtZero: true,
+        grid: { color: 'rgba(255, 255, 255, 0.05)' },
+        ticks: { color: '#ededed', font: { size: 11 } },
+      },
+    },
+    plugins: {
+      legend: { display: false },
+      tooltip: {
+        backgroundColor: 'rgba(26, 26, 26, 0.9)',
+        titleColor: '#ffffff',
+        bodyColor: '#ededed',
+        borderColor: 'rgba(255, 255, 255, 0.1)',
+        borderWidth: 1,
+        padding: 10,
+        boxPadding: 6,
+      },
+    },
+  };
+
+  const miniLineOptions = {
+    responsive: true,
+    maintainAspectRatio: false,
+    scales: {
+      y: { display: false },
+      x: { display: false },
+    },
+    plugins: { legend: { display: false }, tooltip: { enabled: false } },
+  };
+
+  const newJourneyData = {
+    labels: ['W1', 'W2', 'W3', 'W4'],
+    datasets: [
+      {
+        label: 'New',
+        data: [20, 24, 22, 25],
+        borderColor: chartColors.blue,
+        backgroundColor: chartColors.blueAlpha,
+        tension: 0.4,
+        fill: true,
+        pointRadius: 0,
+      },
+    ],
+  };
+
+  const avgDurationData = {
+    labels: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun'],
+    datasets: [
+      {
+        label: 'Avg Days',
+        data: [45, 42, 40, 38, 39, 37],
+        borderColor: chartColors.green,
+        backgroundColor: chartColors.greenAlpha,
+        tension: 0.4,
+        fill: true,
+        pointRadius: 0,
+      },
+    ],
+  };
+
+  return (
+    <div className={`grid grid-cols-1 lg:grid-cols-4 gap-4 ${className}`}>
+      <GlassCard glow="blue">
+        <div className="p-5 text-center">
+          <h3 className="text-zinc-400 text-sm font-medium mb-2">Active Journeys</h3>
+          <AnimatedMetric value={124} className="text-4xl font-bold text-white" />
+        </div>
+      </GlassCard>
+
+      <GlassCard glow="blue">
+        <div className="p-5 text-center">
+          <h3 className="text-zinc-400 text-sm font-medium mb-2">New Journeys (MTD)</h3>
+          <AnimatedMetric value={57} className="text-3xl font-bold text-white" />
+          <div className="w-full h-12 mt-4">
+            <Line options={miniLineOptions} data={newJourneyData} />
+          </div>
+        </div>
+      </GlassCard>
+
+      <GlassCard glow="blue">
+        <div className="p-5 text-center">
+          <h3 className="text-zinc-400 text-sm font-medium mb-2">Avg Journey Length</h3>
+          <AnimatedMetric value={37} suffix=" days" className="text-3xl font-bold text-white" />
+          <div className="w-full h-12 mt-4">
+            <Line options={miniLineOptions} data={avgDurationData} />
+          </div>
+        </div>
+      </GlassCard>
+
+      <GlassCard glow="blue" className="lg:col-span-4">
+        <div className="p-5">
+          <h3 className="text-zinc-400 text-sm font-medium mb-2">Completion Rates</h3>
+          <div className="h-64">
+            <Bar options={barOptions} data={completionData} />
+          </div>
+        </div>
+      </GlassCard>
+    </div>
+  );
+}
+

--- a/src/components/dashboard/claims-management/claims-metrics-panel.tsx
+++ b/src/components/dashboard/claims-management/claims-metrics-panel.tsx
@@ -143,7 +143,7 @@ export function ClaimsMetricsPanel({ className }: ClaimsMetricsPanelProps) {
   return (
     <div className={clsx("grid grid-cols-1 lg:grid-cols-3 gap-4", className)}>
       {/* Top metrics */}
-      <GlassCard className="p-5">
+      <GlassCard className="p-5" glow="blue">
         <h3 className="text-zinc-400 text-sm font-medium mb-4">Clean Claims Rate</h3>
         <div className="flex items-center justify-center h-32">
           <div className="text-center">
@@ -164,7 +164,7 @@ export function ClaimsMetricsPanel({ className }: ClaimsMetricsPanelProps) {
         </div>
       </GlassCard>
       
-      <GlassCard className="p-5">
+      <GlassCard className="p-5" glow="blue">
         <h3 className="text-zinc-400 text-sm font-medium mb-4">Average Reimbursement Time</h3>
         <div className="flex items-center justify-center h-32">
           <div className="text-center">
@@ -184,7 +184,7 @@ export function ClaimsMetricsPanel({ className }: ClaimsMetricsPanelProps) {
         </div>
       </GlassCard>
       
-      <GlassCard className="p-5">
+      <GlassCard className="p-5" glow="blue">
         <h3 className="text-zinc-400 text-sm font-medium mb-4">Total Reimbursement (MTD)</h3>
         <div className="flex items-center justify-center h-32">
           <div className="text-center">
@@ -208,7 +208,7 @@ export function ClaimsMetricsPanel({ className }: ClaimsMetricsPanelProps) {
       </GlassCard>
 
       {/* AR Aging */}
-      <GlassCard className="p-5 lg:col-span-2">
+      <GlassCard className="p-5 lg:col-span-2" glow="blue">
         <h3 className="text-zinc-400 text-sm font-medium mb-4">AR Aging</h3>
         <div className="space-y-4">
           <div className="flex flex-col">
@@ -248,7 +248,7 @@ export function ClaimsMetricsPanel({ className }: ClaimsMetricsPanelProps) {
       </GlassCard>
 
       {/* Payer Performance */}
-      <GlassCard className="p-5">
+      <GlassCard className="p-5" glow="blue">
         <h3 className="text-zinc-400 text-sm font-medium mb-4">Payer Performance</h3>
         <div className="h-64">
           <ChartContainer>

--- a/src/components/dashboard/prior-auth/prior-auth-metrics.tsx
+++ b/src/components/dashboard/prior-auth/prior-auth-metrics.tsx
@@ -50,6 +50,58 @@ export function PriorAuthMetrics({ className }: PriorAuthMetricsProps) {
   const approvalRate = 94;
   const pendingAuths = 46;
   const completedToday = 27;
+
+  const approvalTrendData = {
+    labels: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun'],
+    datasets: [
+      {
+        label: 'Approval %',
+        data: [90, 91, 92, 93, 94, 94],
+        borderColor: chartColors.blue,
+        backgroundColor: chartColors.blueAlpha,
+        borderWidth: 2,
+        tension: 0.4,
+        fill: true,
+        pointRadius: 0,
+      },
+    ],
+  };
+
+  const miniLineOptions = {
+    responsive: true,
+    maintainAspectRatio: false,
+    scales: {
+      y: { display: false },
+      x: { display: false },
+    },
+    plugins: { legend: { display: false }, tooltip: { enabled: false } },
+  };
+
+  const statusTrendData = {
+    labels: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri'],
+    datasets: [
+      {
+        label: 'Pending',
+        data: [40, 42, 39, 50, 46],
+        borderColor: chartColors.yellow,
+        backgroundColor: chartColors.yellowAlpha,
+        tension: 0.4,
+        fill: true,
+        pointRadius: 0,
+        borderWidth: 2,
+      },
+      {
+        label: 'Completed',
+        data: [20, 22, 25, 26, 27],
+        borderColor: chartColors.green,
+        backgroundColor: chartColors.greenAlpha,
+        tension: 0.4,
+        fill: true,
+        pointRadius: 0,
+        borderWidth: 2,
+      },
+    ],
+  };
   
   // Denial reasons chart data
   const denialData = {
@@ -181,7 +233,7 @@ export function PriorAuthMetrics({ className }: PriorAuthMetricsProps) {
   const donutOptions = {
     responsive: true,
     maintainAspectRatio: false,
-    cutout: '70%',
+    cutout: '75%',
     plugins: {
       legend: {
         position: 'right' as const,
@@ -248,7 +300,7 @@ export function PriorAuthMetrics({ className }: PriorAuthMetricsProps) {
       </GlassCard>
       
       {/* Approval Rate */}
-      <GlassCard className="lg:col-span-1">
+      <GlassCard className="lg:col-span-1" glow="blue">
         <div className="p-5 h-full flex flex-col">
           <h3 className="text-zinc-400 text-sm font-medium mb-2">Approval Rate</h3>
           <div className="flex-1 flex flex-col items-center justify-center">
@@ -258,7 +310,7 @@ export function PriorAuthMetrics({ className }: PriorAuthMetricsProps) {
                 suffix="%"
                 className="text-4xl font-bold text-white"
               />
-              <motion.div 
+              <motion.div
                 className="absolute -top-1 -right-7 bg-success rounded-md px-1.5 py-0.5 text-xs font-medium text-white"
                 animate={{ y: [0, -2, 0] }}
                 transition={{ repeat: Infinity, duration: 2 }}
@@ -270,12 +322,15 @@ export function PriorAuthMetrics({ className }: PriorAuthMetricsProps) {
               <CheckIcon className="h-4 w-4 mr-1.5 text-success" />
               <span>Higher than industry average</span>
             </div>
+            <div className="w-full h-16 mt-4">
+              <Line options={miniLineOptions} data={approvalTrendData} />
+            </div>
           </div>
         </div>
       </GlassCard>
       
       {/* Pending & Completed */}
-      <GlassCard className="lg:col-span-1">
+      <GlassCard className="lg:col-span-1" glow="blue">
         <div className="p-5 h-full flex flex-col">
           <h3 className="text-zinc-400 text-sm font-medium mb-4">Status</h3>
           <div className="grid grid-cols-2 gap-4 flex-1">
@@ -302,11 +357,14 @@ export function PriorAuthMetrics({ className }: PriorAuthMetricsProps) {
               </div>
             </div>
           </div>
+          <div className="w-full h-16 mt-4">
+            <Line options={miniLineOptions} data={statusTrendData} />
+          </div>
         </div>
       </GlassCard>
       
       {/* Denial Reasons */}
-      <GlassCard className="lg:col-span-2">
+      <GlassCard className="lg:col-span-2" glow="blue">
         <div className="p-5">
           <h3 className="text-zinc-400 text-sm font-medium mb-2">Denial Reasons</h3>
           <ChartContainer height={200}>
@@ -316,7 +374,7 @@ export function PriorAuthMetrics({ className }: PriorAuthMetricsProps) {
       </GlassCard>
       
       {/* Heat Map Visualization (simplified) */}
-      <GlassCard className="lg:col-span-2">
+      <GlassCard className="lg:col-span-2" glow="blue">
         <div className="p-5">
           <h3 className="text-zinc-400 text-sm font-medium mb-4">Time to Approval by Payer</h3>
           <div className="space-y-3">


### PR DESCRIPTION
## Summary
- expand appeals metrics with success rate and filing trends
- enhance care journeys panel with new journeys and duration metrics
- add completed and no-show metrics to appointments panel

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cf4ffed848329a97939cc2e51360f