### PR TITLE
Add Calm Command Center chat interface

### DIFF
--- a/src/app/dashboard/command-center/page.tsx
+++ b/src/app/dashboard/command-center/page.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import React from 'react';
+import { CalmCommandCenter } from '@/components/chat/calm-command-center';
+
+export default function CommandCenterPage() {
+  return (
+    <div className="h-[calc(100vh-100px)] max-h-[800px]">
+      <CalmCommandCenter />
+    </div>
+  );
+}

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -32,6 +32,7 @@ export default function DashboardLayout({
     { name: 'Prior Authorization', href: '#prior-auth', current: false },
     { name: 'Claims Management', href: '#claims-mgmt', current: false },
     { name: 'Agent Monitoring', href: '#agent-monitor', current: false },
+    { name: 'Command Center', href: '/dashboard/command-center', current: false },
   ];
 
   return (

--- a/src/components/chat/calm-command-center.tsx
+++ b/src/components/chat/calm-command-center.tsx
@@ -1,0 +1,154 @@
+'use client';
+
+import React, { useState, useRef, useEffect } from 'react';
+import {
+  PaperAirplaneIcon,
+  ArrowDownTrayIcon,
+  TrashIcon,
+} from '@heroicons/react/24/solid';
+import clsx from 'clsx';
+import {
+  GlassCard,
+  GlassCardHeader,
+  GlassCardBody,
+  GlassCardFooter,
+} from '@/components/ui/glass-card';
+import { Button } from '@/components/button';
+import {
+  createChatSession,
+  sendMessage,
+  clearChatSession,
+  exportChatHistory,
+  type ChatSession,
+  type Message as CCMessage,
+} from '@/lib/command-center';
+
+export type CalmMessage = CCMessage;
+
+interface CalmCommandCenterProps {
+  initialMessages?: CalmMessage[];
+  onSendMessage?: (message: string) => void;
+}
+
+export function CalmCommandCenter({
+  initialMessages = [],
+  onSendMessage,
+}: CalmCommandCenterProps) {
+  const [messages, setMessages] = useState<CalmMessage[]>(initialMessages);
+  const [text, setText] = useState('');
+  const [session, setSession] = useState<ChatSession | null>(null);
+  const messagesEndRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages]);
+
+  useEffect(() => {
+    if (!session) {
+      setSession(createChatSession('demo-user', { model: 'gpt-4' }));
+    }
+  }, [session]);
+
+  const handleClear = () => {
+    if (session) {
+      clearChatSession(session.id);
+      setSession(createChatSession('demo-user', { model: session.config.model }));
+    }
+    setMessages([]);
+  };
+
+  const handleExport = () => {
+    if (!session) return;
+    const data = exportChatHistory(session.id, 'json');
+    const blob = new Blob([data], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'chat-history.json';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const handleSend = async () => {
+    if (!text.trim() || !session) return;
+    const userMsg: CCMessage = {
+      id: Date.now().toString(),
+      role: 'user',
+      content: text.trim(),
+    };
+    setMessages((prev) => [...prev, userMsg]);
+    setText('');
+    onSendMessage?.(text.trim());
+
+    const assistantId = `${userMsg.id}-a`;
+    setMessages((prev) => [...prev, { id: assistantId, role: 'assistant', content: '' }]);
+
+    for await (const token of sendMessage(session.id, userMsg)) {
+      setMessages((prev) =>
+        prev.map((m) =>
+          m.id === assistantId ? { ...m, content: m.content + token } : m
+        )
+      );
+    }
+  };
+
+  const renderMessage = (msg: CalmMessage) => {
+    const isUser = msg.role === 'user';
+    const bubbleClasses = clsx(
+      'px-3 py-2 rounded-lg max-w-xs break-words',
+      isUser
+        ? 'bg-ai-blue text-white self-end'
+        : 'bg-zinc-800/70 text-zinc-200'
+    );
+
+    return (
+      <div key={msg.id} className={clsx('flex mb-2', isUser ? 'justify-end' : 'justify-start')}>
+        <div className={bubbleClasses}>{msg.content}</div>
+      </div>
+    );
+  };
+
+  return (
+    <GlassCard className="h-full flex flex-col">
+      <GlassCardHeader className="border-b border-zinc-800/20 flex items-center justify-between">
+        <h2 className="font-medium text-zinc-200">Calm Command Center</h2>
+        <div className="flex gap-1">
+          <Button plain onClick={handleExport} aria-label="Export chat">
+            <ArrowDownTrayIcon className="w-4 h-4" />
+          </Button>
+          <Button plain onClick={handleClear} aria-label="Clear chat">
+            <TrashIcon className="w-4 h-4" />
+          </Button>
+        </div>
+      </GlassCardHeader>
+      <GlassCardBody className="flex-1 overflow-y-auto styled-scrollbar-dark space-y-1 p-4">
+        {messages.map(renderMessage)}
+        <div ref={messagesEndRef} />
+      </GlassCardBody>
+      <GlassCardFooter className="border-t border-zinc-800/20">
+        <div className="flex items-center gap-2">
+          <input
+            type="text"
+            className="flex-1 bg-zinc-800/50 text-zinc-200 placeholder-zinc-500 rounded-lg px-3 py-2 focus:outline-none"
+            placeholder="Type a message"
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                handleSend();
+              }
+            }}
+          />
+          <Button
+            onClick={handleSend}
+            className="bg-ai-blue text-white px-3 py-2 flex items-center gap-1"
+          >
+            <PaperAirplaneIcon className="w-4 h-4" />
+            <span className="sr-only">Send</span>
+          </Button>
+        </div>
+      </GlassCardFooter>
+    </GlassCard>
+  );
+}

--- a/src/lib/command-center.ts
+++ b/src/lib/command-center.ts
@@ -1,0 +1,328 @@
+export interface ChatConfig {
+  model: 'gpt-4' | 'gpt-4-turbo'
+}
+
+export interface Message {
+  id: string
+  role: 'user' | 'assistant' | 'system'
+  content: string
+}
+
+export interface Context {
+  [key: string]: any
+}
+
+export interface ChatSession {
+  id: string
+  userId: string
+  config: ChatConfig
+  history: Message[]
+  context: Context
+}
+
+export type StreamingResponse = AsyncGenerator<string>
+
+type SessionStore = Map<string, ChatSession>
+
+const sessions: SessionStore = new Map()
+
+export function createChatSession(userId: string, config: ChatConfig): ChatSession {
+  const session: ChatSession = {
+    id: Date.now().toString(),
+    userId,
+    config,
+    history: [],
+    context: {}
+  }
+  sessions.set(session.id, session)
+  return session
+}
+
+export async function* sendMessage(sessionId: string, message: Message): StreamingResponse {
+  const session = sessions.get(sessionId)
+  if (!session) return
+  session.history.push(message)
+  // Placeholder assistant response: echo message
+  const reply = `Echo: ${message.content}`
+  for (const char of reply) {
+    await new Promise(r => setTimeout(r, 20))
+    yield char
+  }
+  session.history.push({ id: `${message.id}-a`, role: 'assistant', content: reply })
+}
+
+export function getChatHistory(sessionId: string): Message[] {
+  return sessions.get(sessionId)?.history ?? []
+}
+
+export function updateChatContext(sessionId: string, context: Context): void {
+  const session = sessions.get(sessionId)
+  if (session) {
+    session.context = { ...session.context, ...context }
+  }
+}
+
+export function clearChatSession(sessionId: string): void {
+  sessions.delete(sessionId)
+}
+
+export function exportChatHistory(sessionId: string, format: 'json' | 'markdown'): string {
+  const history = getChatHistory(sessionId)
+  if (format === 'json') {
+    return JSON.stringify(history, null, 2)
+  }
+  return history.map(m => `**${m.role}:** ${m.content}`).join('\n')
+}
+
+// AI Model Integration stubs
+export interface OpenAIClient {
+  apiKey: string
+  model: 'gpt-4' | 'gpt-4-turbo'
+}
+
+export function initializeOpenAI(apiKey: string, model: 'gpt-4' | 'gpt-4-turbo'): OpenAIClient {
+  return { apiKey, model }
+}
+
+export async function* streamCompletion(prompt: string, tools: Tool[] = []): AsyncGenerator<string> {
+  // Dummy completion streaming each word
+  const words = `Response to: ${prompt}`.split(' ')
+  for (const w of words) {
+    await new Promise(r => setTimeout(r, 50))
+    yield w + ' '
+  }
+}
+
+export type ToolResult = any
+
+export function executeToolCall(toolName: string, args: any): ToolResult {
+  return { tool: toolName, args }
+}
+
+export type FunctionCallHandler = (...args: any[]) => any
+
+export function handleFunctionCalling(functions: Function[]): FunctionCallHandler {
+  return (...args) => functions.map(fn => fn(...args))
+}
+
+export function manageChatContext(messages: Message[], maxTokens: number): Message[] {
+  return messages.slice(-maxTokens)
+}
+
+// RAG stubs
+export interface Document { id: string; text: string }
+export type VectorStore = { vectors: number[][]; documents: Document[] }
+
+export function createVectorStore(documents: Document[]): VectorStore {
+  return { vectors: documents.map(() => []), documents }
+}
+
+export function embedDocuments(texts: string[]): number[][] {
+  return texts.map(() => [])
+}
+
+export function searchSimilarDocuments(query: string, k: number): Document[] {
+  return []
+}
+
+export function augmentPromptWithContext(prompt: string, documents: Document[]): string {
+  return `${prompt}\nContext:${documents.map(d => d.text).join(' ')}`
+}
+
+export function updateVectorStore(newDocuments: Document[]): void {
+  // no-op placeholder
+}
+
+// Tool system
+export interface Tool {
+  name: string
+  description: string
+  parameters: any
+  execute(args: any): Promise<ToolResult>
+}
+
+export async function webSearch(query: string): Promise<any[]> {
+  return [{ title: 'result', url: 'https://example.com', query }]
+}
+
+export async function browserAutomation(actions: any[]): Promise<any> {
+  return { actions }
+}
+
+export async function codeGeneration(prompt: string, language: string): Promise<any> {
+  return { language, code: `// code for ${prompt}` }
+}
+
+export async function fileOperations(operation: 'read' | 'write' | 'edit', path: string, content?: string): Promise<any> {
+  return { operation, path, content }
+}
+
+export async function dataAnalysis(data: any[], operation: string): Promise<any> {
+  return { data, operation }
+}
+
+export async function perplexityResearch(query: string, options?: any): Promise<any> {
+  return { query, options }
+}
+
+export async function mcpToolExecute(server: string, tool: string, args: any): Promise<any> {
+  return { server, tool, args }
+}
+
+// Browser automation stubs
+export interface Browser {}
+export interface Page {}
+
+export async function launchBrowser(headless: boolean): Promise<Browser> {
+  return {}
+}
+
+export async function navigateToUrl(url: string): Promise<Page> {
+  return {}
+}
+
+export async function captureScreenshot(selector?: string): Promise<Buffer> {
+  return Buffer.from('')
+}
+
+export async function fillForm(formData: Record<string, string>): Promise<void> {}
+
+export async function clickElement(selector: string): Promise<void> {}
+
+export async function extractPageData(selectors: string[]): Promise<Record<string, string>> {
+  return {}
+}
+
+export async function executeBrowserScript(script: string): Promise<any> {
+  return {}
+}
+
+// Healthcare stubs
+export interface PatientInfo {}
+export interface CarePlan {}
+export interface ADPIEPlan {}
+export interface MedicalScore {}
+export interface ValidationResult {}
+export interface HealthData {}
+export interface Report {}
+
+export async function generateCarePlan(patientData: PatientInfo, conditions: string[]): Promise<CarePlan> {
+  return {}
+}
+
+export async function processADPIE(assessment: string): Promise<ADPIEPlan> {
+  return {}
+}
+
+export async function calculateMedicalScores(calculator: string, inputs: any): Promise<MedicalScore> {
+  return {}
+}
+
+export function validateHealthcareData(data: any): ValidationResult {
+  return {}
+}
+
+export async function generateHealthReport(data: HealthData): Promise<Report> {
+  return {}
+}
+
+// Code development stubs
+export interface CodeContext {}
+export interface CodeGenResult {}
+export interface CodeReview {}
+export interface RefactoredCode {}
+export interface DebugSolution {}
+export interface CodeExplanation {}
+
+export async function generateCode(prompt: string, context: CodeContext): Promise<CodeGenResult> {
+  return {}
+}
+
+export async function reviewCode(code: string, language: string): Promise<CodeReview> {
+  return {}
+}
+
+export async function refactorCode(code: string, instructions: string): Promise<RefactoredCode> {
+  return {}
+}
+
+export async function debugCode(code: string, error: string): Promise<DebugSolution> {
+  return {}
+}
+
+export async function explainCode(code: string): Promise<CodeExplanation> {
+  return {}
+}
+
+// Streaming & real-time stubs
+export function createStreamingResponse(generator: AsyncGenerator): ReadableStream<any> {
+  const encoder = new TextEncoder()
+  return new ReadableStream({
+    async start(controller) {
+      for await (const chunk of generator) {
+        controller.enqueue(encoder.encode(String(chunk)))
+      }
+      controller.close()
+    }
+  })
+}
+
+export function handleWebSocketConnection(socket: any): void {}
+
+export function broadcastUpdate(sessionId: string, update: any): void {}
+
+export function manageTypingIndicator(sessionId: string, isTyping: boolean): void {}
+
+export async function* streamTokens(text: string, delay: number): AsyncGenerator<string> {
+  for (const char of text) {
+    await new Promise(r => setTimeout(r, delay))
+    yield char
+  }
+}
+
+// Memory & context stubs
+export function saveConversationMemory(sessionId: string, summary: string): void {}
+
+export function retrieveRelevantMemories(query: string): any[] {
+  return []
+}
+
+export function compressConversationHistory(messages: Message[]): Message[] {
+  return messages
+}
+
+export function extractKeyTopics(conversation: Message[]): string[] {
+  return []
+}
+
+export function manageContextWindow(messages: Message[], limit: number): Message[] {
+  return messages.slice(-limit)
+}
+
+// UI component stubs (server-side rendering placeholders)
+import React from 'react'
+
+export function renderChatMessage(message: Message): React.ReactElement {
+  return <div>{message.content}</div>
+}
+
+export function renderTypingIndicator(show: boolean): React.ReactElement {
+  return <div>{show ? 'Typing...' : ''}</div>
+}
+
+export function renderToolExecution(tool: string, status: string): React.ReactElement {
+  return <div>{tool}: {status}</div>
+}
+
+export function renderCodeBlock(code: string, language: string): React.ReactElement {
+  return <pre>{code}</pre>
+}
+
+export function renderMarkdown(content: string): React.ReactElement {
+  return <div>{content}</div>
+}
+
+export function renderFileAttachment(file: File): React.ReactElement {
+  return <div>{file.name}</div>
+}
+


### PR DESCRIPTION
## Summary
- implement CalmCommandCenter session logic and streaming
- stub out command center functions in new `command-center.ts`
- add export & clear controls to command center chat UI

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684cf85a8e848329ac252f203dba9c2d